### PR TITLE
Protected against registration overwriting

### DIFF
--- a/src/UnityConfiguration/RegistrationExpression.cs
+++ b/src/UnityConfiguration/RegistrationExpression.cs
@@ -52,7 +52,7 @@ namespace UnityConfiguration
 
                 });
             }
-            else
+            else if (container.IsRegistered(typeFrom, name) == false)
             {
                 container.RegisterType(typeFrom, typeTo, name, lifetimeManagerFunc(), injectionMembers);
             }


### PR DESCRIPTION
The issue here is that UnityContainer will replace a registration if there is an existing registration for the from type and name. This is a problem because convention registrations shouldn't overwrite anything that has already been configured.
